### PR TITLE
Created account_name in createKey request and in usage logs

### DIFF
--- a/fastapi_simple_security/_sqlite_access.py
+++ b/fastapi_simple_security/_sqlite_access.py
@@ -29,6 +29,7 @@ class SQLiteAccess:
             api_key TEXT PRIMARY KEY,
             is_active INTEGER,
             never_expire INTEGER,
+            account_name TEXT,
             expiration_date TEXT,
             latest_query_date TEXT,
             total_queries INTEGER)
@@ -36,7 +37,7 @@ class SQLiteAccess:
             )
             connection.commit()
 
-    def create_key(self, never_expire) -> str:
+    def create_key(self, never_expire, account_name) -> str:
         api_key = str(uuid.uuid4())
 
         with sqlite3.connect(self.db_location) as connection:
@@ -44,13 +45,14 @@ class SQLiteAccess:
             c.execute(
                 """
                 INSERT INTO fastapi_simple_security 
-                (api_key, is_active, never_expire, expiration_date, latest_query_date, total_queries) 
-                VALUES(?, ?, ?, ?, ?, ?)
+                (api_key, is_active, never_expire, account_name, expiration_date, latest_query_date, total_queries) 
+                VALUES(?, ?, ?, ?, ?, ?, ?)
             """,
                 (
                     api_key,
                     1,
                     1 if never_expire else 0,
+                    account_name,
                     (datetime.utcnow() + timedelta(days=self.expiration_limit)).isoformat(timespec="seconds"),
                     None,
                     0,
@@ -196,7 +198,7 @@ class SQLiteAccess:
         Returns usage stats for all API keys
 
         Returns:
-            a list of tuples with values being api_key, is_active, expiration_date, latest_query_date, and total_queries
+            a list of tuples with values being api_key, is_active, account_name, expiration_date, latest_query_date, and total_queries
         """
         with sqlite3.connect(self.db_location) as connection:
             c = connection.cursor()
@@ -204,7 +206,7 @@ class SQLiteAccess:
             # TODO Add filtering somehow
             c.execute(
                 """
-            SELECT api_key, is_active, never_expire, expiration_date, latest_query_date, total_queries 
+            SELECT api_key, is_active, never_expire, account_name, expiration_date, latest_query_date, total_queries 
             FROM fastapi_simple_security
             ORDER BY latest_query_date DESC
             """,

--- a/fastapi_simple_security/endpoints.py
+++ b/fastapi_simple_security/endpoints.py
@@ -13,15 +13,15 @@ show_endpoints = False if "FASTAPI_SIMPLE_SECURITY_HIDE_DOCS" in os.environ else
 
 
 @api_key_router.get("/new", dependencies=[Depends(secret_based_security)], include_in_schema=show_endpoints)
-def get_new_api_key(never_expires=None) -> str:
+def get_new_api_key(never_expires=None, account_name: Optional[str] = "Not Provided") -> str:
     """
     Args:
         never_expires: if set, the created API key will never be considered expired
-
+        account_name: if set, creates a field in the database table that corresponds to the account/client who utilizes the API Key.
     Returns:
         api_key: a newly generated API key
     """
-    return sqlite_access.create_key(never_expires)
+    return sqlite_access.create_key(never_expires, account_name)
 
 
 @api_key_router.get("/revoke", dependencies=[Depends(secret_based_security)], include_in_schema=show_endpoints)
@@ -51,6 +51,7 @@ class UsageLog(BaseModel):
     api_key: str
     is_active: bool
     never_expire: bool
+    account_name: str
     expiration_date: str
     latest_query_date: Optional[str]
     total_queries: int
@@ -75,9 +76,10 @@ def get_api_key_usage_logs():
                 api_key=row[0],
                 is_active=row[1],
                 never_expire=row[2],
-                expiration_date=row[3],
-                latest_query_date=row[4],
-                total_queries=row[5],
+                account_name=row[3],
+                expiration_date=row[4],
+                latest_query_date=row[5],
+                total_queries=row[6],
             )
             for row in sqlite_access.get_usage_stats()
         ]


### PR DESCRIPTION
Updated the create api request with an additional field 'account_name' in order to create a link between a client/account and the corresponding generated API key. The field is optional and will simply insert a string of "Not Provided" in the database if not provided.

