### PR TITLE
Replaced underscore with hyphen in SECRET_KEY_NAME

### DIFF
--- a/fastapi_simple_security/_security_secret.py
+++ b/fastapi_simple_security/_security_secret.py
@@ -18,7 +18,7 @@ except KeyError:
         f"\t{SECRET=}"
     )
 
-SECRET_KEY_NAME = "secret_key"
+SECRET_KEY_NAME = "secret-key"  # Note: By default, nginx silently drops headers with underscores. Use hyphens instead.
 
 secret_header = APIKeyHeader(name=SECRET_KEY_NAME, scheme_name="Secret header", auto_error=False)
 


### PR DESCRIPTION
Because nginx by default drops headers with underscores. 

**Missing (disappearing) HTTP Headers**

> If you do not explicitly set underscores_in_headers on;, NGINX will silently drop HTTP headers with underscores (which are perfectly valid according to the HTTP standard). This is done in order to prevent ambiguities when mapping headers to CGI variables as both dashes and underscores are mapped to underscores during that process.
https://www.nginx.com/nginx-wiki/build/dirhtml/start/topics/tutorials/config_pitfalls/

While it seems possible to reconfigure nginx to accept underscored headers, just getting to the bottom of the issue could take some time (it did for me) and it might be desirable to avoid jumping through hoops by simply replacing the underscore with a hyphen in the SECRET_KEY_NAME, to be secret-key. 