### PR TITLE
Changed underscore to hyphen in API_KEY_NAME

### DIFF
--- a/fastapi_simple_security/security_api_key.py
+++ b/fastapi_simple_security/security_api_key.py
@@ -5,7 +5,7 @@ from starlette.status import HTTP_403_FORBIDDEN
 
 from fastapi_simple_security._sqlite_access import sqlite_access
 
-API_KEY_NAME = "api_key"
+API_KEY_NAME = "api-key"
 
 api_key_query = APIKeyQuery(name=API_KEY_NAME, scheme_name="API key query", auto_error=False)
 api_key_header = APIKeyHeader(name=API_KEY_NAME, scheme_name="API key header", auto_error=False)


### PR DESCRIPTION
Yet another small change in the same line as the previous fix for underscored header (where nginx complains). 
This also will be a breaking change, but hopefully the users are pinning their releases and it'll be a small thing to fix, and for new users it'll be easier to setup. 
While a new package is not released it makes sense to have it all consistent header-wise. 